### PR TITLE
Sentry nextjs deprecations

### DIFF
--- a/app/(dashboard)/dashboard/layout.tsx
+++ b/app/(dashboard)/dashboard/layout.tsx
@@ -1,8 +1,7 @@
 "use client"
 
-// Force dynamic rendering - layout uses Clerk hooks that need runtime
+// Force dynamic rendering - layout uses Clerk hooks that require client-side auth state
 export const dynamic = 'force-dynamic'
-export const runtime = 'edge'
 
 import { useState } from "react"
 import { useUser, useClerk, SignedIn, RedirectToSignIn } from "@/components/clerk-safe"

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -43,42 +43,42 @@ const nextConfig = {
   },
 }
 
-export default withSentryConfig(nextConfig, {
-  // For all available options, see:
-  // https://github.com/getsentry/sentry-webpack-plugin#options
+const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
+const isSentryUploadEnabled = Boolean(sentryAuthToken);
 
+export default withSentryConfig(nextConfig, {
+  // Core Sentry settings (also configurable via env vars)
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
+  authToken: sentryAuthToken,
 
   // Only print logs for uploading source maps in CI
   silent: !process.env.CI,
 
-  // For all available options, see:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+  // Disable release + sourcemap upload when no auth token is present.
+  // This prevents build-time warnings in local/dev environments.
+  release: {
+    create: isSentryUploadEnabled,
+  },
+  sourcemaps: {
+    disable: !isSentryUploadEnabled,
+  },
 
   // Upload a larger set of source maps for prettier stack traces (increases build time)
   widenClientFileUpload: true,
 
-  // Automatically annotate React components to show their full name in breadcrumbs and session replay
-  reactComponentAnnotation: {
-    enabled: true,
-  },
-
   // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
-  // This can increase your server load as well as your hosting bill.
-  // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
-  // side errors will fail.
+  // Note: ensure this won't conflict with your proxy file matchers.
   tunnelRoute: "/monitoring",
 
-  // Hides source maps from generated client bundles
-  hideSourceMaps: true,
-
-  // Automatically tree-shake Sentry logger statements to reduce bundle size
-  disableLogger: true,
-
-  // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
-  // See the following for more information:
-  // https://docs.sentry.io/product/crons/
-  // https://vercel.com/docs/cron-jobs
-  automaticVercelMonitors: true,
+  // NOTE: These options were previously top-level but are now configured under `webpack.*`.
+  webpack: {
+    treeshake: {
+      removeDebugLogging: true,
+    },
+    automaticVercelMonitors: true,
+    reactComponentAnnotation: {
+      enabled: true,
+    },
+  },
 });

--- a/proxy.ts
+++ b/proxy.ts
@@ -16,7 +16,7 @@ const isSupabaseConfigured = () => {
   return Boolean(url && key)
 }
 
-export async function middleware(req: NextRequest) {
+export async function proxy(req: NextRequest) {
   const res = NextResponse.next()
 
   // Check if route is protected
@@ -72,3 +72,4 @@ export const config = {
     "/(api|trpc)(.*)",
   ],
 }
+


### PR DESCRIPTION
Update Sentry config, migrate Next.js middleware, and remove edge runtime to clear all build warnings.

The Sentry options were deprecated and moved under `webpack.*`, and release/sourcemap uploads are now conditionally disabled to prevent "no auth token" warnings. The `middleware.ts` file convention was deprecated in favor of `proxy.ts`. The `runtime = 'edge'` flag was removed from the dashboard layout as it was causing a warning about disabling static generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8a4ef25-b9d9-4444-9ddb-eba5d2a9b1a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e8a4ef25-b9d9-4444-9ddb-eba5d2a9b1a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

