### PR TITLE
Interactive redeploy build error

### DIFF
--- a/app/interactive/page.tsx
+++ b/app/interactive/page.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import InteractivePortrait from "@/components/interactive-portrait"
+
+export default function InteractivePage() {
+  return (
+    <div className="relative min-h-screen w-full overflow-hidden">
+      <InteractivePortrait />
+    </div>
+  )
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Add `/interactive` page to resolve a missing route and build error.

The user requested the `/interactive` page, which was missing, leading to a build error. This PR creates the page using the existing `InteractivePortrait` component.

---
<a href="https://cursor.com/background-agent?bcId=bc-a06f904b-2382-435f-82e4-7645330cd247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a06f904b-2382-435f-82e4-7645330cd247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

