### PR TITLE
Background orb orbiting animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -583,6 +583,26 @@ body {
     will-change: transform, opacity;
   }
 
+  @keyframes depth-orb-orbit {
+    0% {
+      transform: rotate(0deg) translateX(var(--orb-orbit-radius, 24px))
+        translateY(calc(var(--orb-orbit-radius, 24px) * 0.35)) rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg) translateX(var(--orb-orbit-radius, 24px))
+        translateY(calc(var(--orb-orbit-radius, 24px) * 0.35)) rotate(-360deg);
+    }
+  }
+
+  /* Inner element so GSAP can own the wrapper transform */
+  .depth-orb__inner {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    will-change: transform;
+    animation: depth-orb-orbit var(--orb-orbit-duration, 180s) linear infinite;
+  }
+
   .orb-orange {
     background: radial-gradient(circle, rgba(255, 106, 26, 0.4) 0%, transparent 70%);
   }
@@ -593,6 +613,12 @@ body {
 
   .orb-white {
     background: radial-gradient(circle, rgba(255, 255, 255, 0.1) 0%, transparent 70%);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .depth-orb__inner {
+      animation: none;
+    }
   }
 
   /* Section base for horizontal scroll (legacy) */

--- a/app/landing/page.tsx
+++ b/app/landing/page.tsx
@@ -222,9 +222,39 @@ export default function LandingPage() {
 
       {/* Orange depth orbs */}
       <div className="fixed inset-0 z-0 pointer-events-none overflow-hidden">
-        <div className="depth-orb orb-orange w-[680px] h-[680px] top-[8%] left-[-14%]" />
-        <div className="depth-orb orb-orange w-[520px] h-[520px] top-[42%] right-[-12%] opacity-70" />
-        <div className="depth-orb orb-orange w-[420px] h-[420px] bottom-[-12%] right-[12%] opacity-60" />
+        <div
+          className="depth-orb w-[680px] h-[680px] top-[8%] left-[-14%]"
+          style={
+            {
+              ["--orb-orbit-radius" as any]: "34px",
+              ["--orb-orbit-duration" as any]: "160s",
+            } as any
+          }
+        >
+          <div className="depth-orb__inner orb-orange" />
+        </div>
+        <div
+          className="depth-orb w-[520px] h-[520px] top-[42%] right-[-12%] opacity-70"
+          style={
+            {
+              ["--orb-orbit-radius" as any]: "26px",
+              ["--orb-orbit-duration" as any]: "190s",
+            } as any
+          }
+        >
+          <div className="depth-orb__inner orb-orange" />
+        </div>
+        <div
+          className="depth-orb w-[420px] h-[420px] bottom-[-12%] right-[12%] opacity-60"
+          style={
+            {
+              ["--orb-orbit-radius" as any]: "22px",
+              ["--orb-orbit-duration" as any]: "220s",
+            } as any
+          }
+        >
+          <div className="depth-orb__inner orb-orange" />
+        </div>
       </div>
 
       <div className="relative z-10 flex flex-col">


### PR DESCRIPTION
Add a slow, subtle orbiting animation to the G-stop background orbs, ensuring it's smooth, non-distracting, and respects `prefers-reduced-motion`.

---
<a href="https://cursor.com/background-agent?bcId=bc-506fec2c-a621-4583-bc00-e5ccb221b446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-506fec2c-a621-4583-bc00-e5ccb221b446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

